### PR TITLE
Add null_casts_as_array: weaker version of null_casts_as_any_type

### DIFF
--- a/src/Phan/Config.php
+++ b/src/Phan/Config.php
@@ -130,6 +130,13 @@ class Config
         // defined.
         'allow_missing_properties' => false,
 
+        // Allow null to be cast as any array-like type and for any
+        // array-like type to be cast to null. Setting this to false
+        // will cut down on false positives.
+        // This is an incremental step in migrating away from null_casts_as_any_type.
+        // If null_casts_as_any_type is true, this has no effect.
+        'null_casts_as_array' => false,
+
         // Allow null to be cast as any type and for any
         // type to be cast to null. Setting this to false
         // will cut down on false positives.
@@ -139,7 +146,7 @@ class Config
         // are treated as if they can cast to each other.
         'scalar_implicit_cast' => false,
 
-        // If enabled, scalars (int, float, bool, string, null)
+        // If this has entries, scalars (int, float, bool, string, null)
         // are treated as if they can cast to any element in this nested list of types.
         // Stricter than scalar_implicit_cast.
         // E.g. ['int' => ['float', 'string'], 'float' => ['int'], 'string' => ['int'], 'null' => ['string']]

--- a/src/Phan/Language/Type.php
+++ b/src/Phan/Language/Type.php
@@ -1040,6 +1040,8 @@ class Type
             // A nullable type cannot cast to a non-nullable type (Except when null_casts_as_any_type is true)
             if (Config::get()->null_casts_as_any_type) {
                 return true;
+            } else if (Config::get()->null_casts_as_array && $type->isArrayLike()) {
+                return true;
             }
             if (!$type->getIsNullable()) {
                 return false;

--- a/src/Phan/Language/Type/NullType.php
+++ b/src/Phan/Language/Type/NullType.php
@@ -42,6 +42,7 @@ class NullType extends ScalarType
     {
         // null_casts_as_any_type means that null or nullable can cast to any type?
         return Config::get()->null_casts_as_any_type
+            || (Config::get()->null_casts_as_array && $type->isArrayLike())
             || parent::canCastToNonNullableType($type);
     }
 

--- a/src/Phan/Language/UnionType.php
+++ b/src/Phan/Language/UnionType.php
@@ -711,6 +711,13 @@ class UnionType implements \Serializable
             ) {
                 return true;
             }
+        } else if (Config::get()->null_casts_as_array) {
+            // null <-> null
+            if (($this->isType(NullType::instance(false)) && $target->hasArrayLike())
+                || ($target->isType(NullType::instance(false)) && $this->hasArrayLike())
+            ) {
+                return true;
+            }
         }
 
         // mixed <-> mixed


### PR DESCRIPTION
(can be used in combination with scalar_implicit_partial to gradually
move away from null_casts_as_any_type)