### PR TITLE
Improve daemon mode, stop keeping around old issues for method signatures

### DIFF
--- a/src/Phan/CodeBase.php
+++ b/src/Phan/CodeBase.php
@@ -411,6 +411,12 @@ class CodeBase
             }
             $this->name_method_map[$method->getFQSEN()->getNameWithAlternateId()]->attach($method);
         }
+        if ($this->undo_tracker) {
+            // The addClass's recordUndo should remove the class map. Only need to remove it from func_and_method_set
+            $this->undo_tracker->recordUndo(function(CodeBase $inner) use($method) {
+                $inner->func_and_method_set->detach($method);
+            });
+        }
     }
 
     /**

--- a/src/Phan/Output/Collector/BufferingCollector.php
+++ b/src/Phan/Output/Collector/BufferingCollector.php
@@ -76,6 +76,22 @@ final class BufferingCollector implements IssueCollectorInterface
     }
 
     /**
+     * Remove all collected issues (from the parse phase) for the given file paths.
+     * Called from daemon mode.
+     *
+     * @param string[] $files - the relative paths to those files
+     * @return void
+     */
+    public function removeIssuesForFiles(array $files) {
+        $file_set = array_flip($files);
+        foreach ($this->issues as $key => $issue) {
+            if (array_key_exists($issue->getFile(), $file_set)) {
+                unset($this->issues[$key]);
+            }
+        }
+    }
+
+    /**
      * Removes all collected issues.
      */
     public function reset()

--- a/src/Phan/Output/Collector/ParallelChildCollector.php
+++ b/src/Phan/Output/Collector/ParallelChildCollector.php
@@ -82,6 +82,17 @@ class ParallelChildCollector implements IssueCollectorInterface
     }
 
     /**
+     * Remove all collected issues (from the parse phase) for the given file paths.
+     * Called from daemon mode.
+     *
+     * @param string[] $files - the relative paths to those files
+     * @return void
+     */
+    public function removeIssuesForFiles(array $files) {
+        return;  // Never going to be called - daemon mode isn't combined with parallel execution.
+    }
+
+    /**
      * This method has not effect on a ParallelChildCollector.
      */
     public function reset()

--- a/src/Phan/Output/Collector/ParallelParentCollector.php
+++ b/src/Phan/Output/Collector/ParallelParentCollector.php
@@ -132,6 +132,17 @@ class ParallelParentCollector implements IssueCollectorInterface
     }
 
     /**
+     * Remove all collected issues (from the parse phase) for the given file paths.
+     * Called from daemon mode.
+     *
+     * @param string[] $files - the relative paths to those files
+     * @return void
+     */
+    public function removeIssuesForFiles(array $files) {
+        return;  // Never going to be called - daemon mode isn't combined with parallel execution.
+    }
+
+    /**
      * @return IssueInstance[]
      */
     public function getCollectedIssues() : array

--- a/src/Phan/Output/IssueCollectorInterface.php
+++ b/src/Phan/Output/IssueCollectorInterface.php
@@ -18,6 +18,15 @@ interface IssueCollectorInterface
     public function getCollectedIssues():array;
 
     /**
+     * Remove all collected issues (from the parse phase) for the given file paths.
+     * Called from daemon mode.
+     *
+     * @param string[] $files - the relative paths to those files
+     * @return void
+     */
+    public function removeIssuesForFiles(array $files);
+
+    /**
      * Remove all collected issues.
      */
     public function reset();


### PR DESCRIPTION
This undo tracker was failing to remove the old versions of methods,
so the issues on signatures (E.g. undeclared parameters)
used to stay around for subsequent runs, in the parse phase.

Also, remove any issues found in the parse phase for old versions of
files