### PR TITLE
Fix dead code detection of unused methods, add tests

### DIFF
--- a/src/Phan/Analysis/ReferenceCountsAnalyzer.php
+++ b/src/Phan/Analysis/ReferenceCountsAnalyzer.php
@@ -7,6 +7,7 @@ use Phan\CodeBase\ClassMap;
 use Phan\Config;
 use Phan\Issue;
 use Phan\Language\Element\AddressableElement;
+use Phan\Language\Element\ClassConstant;
 use Phan\Language\Element\ClassElement;
 use Phan\Language\Element\Method;
 use Phan\Language\Element\Property;
@@ -156,6 +157,12 @@ class ReferenceCountsAnalyzer
 
         // Skip methods that are overrides of other methods
         if ($element instanceof ClassElement) {
+            if ($element instanceof ClassConstant) {
+                // should not warn about self::class
+                if (strcasecmp($element->getName(), 'class') === 0) {
+                    return;
+                }
+            }
             if ($element->getIsOverride()) {
                 return;
             }
@@ -164,7 +171,7 @@ class ReferenceCountsAnalyzer
 
             // Don't analyze elements defined in a parent
             // class
-            if ((string)$class_fqsen !== $element->getFQSEN()) {
+            if ($class_fqsen != $element->getDefiningClassFQSEN()) {
                 return;
             }
 

--- a/src/Phan/Language/Element/Clazz.php
+++ b/src/Phan/Language/Element/Clazz.php
@@ -782,6 +782,8 @@ class Clazz extends AddressableElement
             );
             if ($is_static && !$property->isStatic()) {
                 // TODO: add additional warning about possible static/non-static confusion?
+                echo "\nUndeclaredStaticProperty $property_name\n";
+                debug_print_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS);
                 throw new IssueException(
                     Issue::fromType(Issue::UndeclaredStaticProperty)(
                         $context->getFile(),

--- a/tests/plugin_test/expected/all_output.expected
+++ b/tests/plugin_test/expected/all_output.expected
@@ -8,4 +8,6 @@ src/000_plugins.php:40 PhanPluginNonBoolInLogicalArith Non bool value in logical
 src/000_plugins.php:47 PhanPluginNumericalComparison non numerical values compared by the operators '==' or '!=='
 src/000_plugins.php:49 PhanPluginNumericalComparison numerical values compared by the operators '===' or '!=='
 src/000_plugins.php:55 UnusedSuppression Element \testUnusedSuppressionPlugin suppresses issue PhanParamTooFew but does not use it
-src/000_plugins.php:61 PhanUnreferencedMethod Possibly zero references to method \testUnreferencedFunction
+src/000_plugins.php:62 PhanUnreferencedMethod Possibly zero references to method \FooTest::unused_static_method
+src/000_plugins.php:68 PhanUnreferencedMethod Possibly zero references to method \FooSubclassTest::unused_static_method_in_subclass
+src/000_plugins.php:78 PhanUnreferencedMethod Possibly zero references to method \testUnreferencedFunction

--- a/tests/plugin_test/src/000_plugins.php
+++ b/tests/plugin_test/src/000_plugins.php
@@ -57,5 +57,22 @@ function testUnusedSuppressionPlugin() {
 }
 testUnusedSuppressionPlugin();
 
+class FooTest {
+    // Dead code detection should detect this
+    public static function unused_static_method() {
+    }
+}
+
+class FooSubclassTest extends FooTest {
+    // Dead code detection should detect this, but shouldn't warn twice about unused_static_method
+    public static function unused_static_method_in_subclass() {
+        self::used_method(self::class);
+    }
+
+    public static function used_method(string $class) {}
+}
+
+$c = new FooTest();
+
 // Dead code detection should detect this
 function testUnreferencedFunction() {}


### PR DESCRIPTION
The check if an fqsen belonged to a parent was always true, so methods
were never checked for dead code.