### PR TITLE
Remove unnecessary uses of `implode()`

### DIFF
--- a/src/Phan/AST/TolerantASTConverter/NodeDumper.php
+++ b/src/Phan/AST/TolerantASTConverter/NodeDumper.php
@@ -105,11 +105,11 @@ class NodeDumper
                 $this->include_offset ? ' (@' . $ast_node->getStart() . ')' : ''
             );
 
-            $result = [$first_part];
+            $result = $first_part;
             foreach ($ast_node->getChildNodesAndTokens() as $name => $child) {
-                $result[] = $this->dumpTreeAsString($child, $name, $padding . $this->indent);
+                $result .= $this->dumpTreeAsString($child, $name, $padding . $this->indent);
             }
-            return \implode('', $result);
+            return $result;
         } elseif ($ast_node instanceof Token) {
             return \sprintf(
                 "%s%s%s: %s%s%s: %s\n",

--- a/src/Phan/Config.php
+++ b/src/Phan/Config.php
@@ -937,10 +937,7 @@ class Config
             return $relative_path;
         }
 
-        return \implode(DIRECTORY_SEPARATOR, [
-            Config::getProjectRootDirectory(),
-            $relative_path
-        ]);
+        return Config::getProjectRootDirectory() . DIRECTORY_SEPARATOR .  $relative_path;
     }
 }
 

--- a/src/Phan/Language/FQSEN/FullyQualifiedFunctionName.php
+++ b/src/Phan/Language/FQSEN/FullyQualifiedFunctionName.php
@@ -71,7 +71,7 @@ class FullyQualifiedFunctionName extends FullyQualifiedGlobalStructuralElement i
 
         // For functions we don't use the context's namespace if
         // there is no NS on the call.
-        $namespace = implode('\\', array_filter($parts));
+        $namespace = \implode('\\', array_filter($parts));
 
         return static::make(
             $namespace,
@@ -84,12 +84,11 @@ class FullyQualifiedFunctionName extends FullyQualifiedGlobalStructuralElement i
         Context $context,
         Node $node
     ) : FullyQualifiedFunctionName {
-        $hash_material = implode('|', [
-            $context->getFile(),
-            $context->getLineNumberStart(),
-            $node->children['__declId'],
-        ]);
-        // TODO: hash args
+        $hash_material =
+            $context->getFile() . '|' .
+            $context->getLineNumberStart() . '|' .
+            $node->children['__declId'];
+
         $name = 'closure_' . substr(md5($hash_material), 0, 12);
 
         return static::fromStringInContext(

--- a/src/Phan/Language/FQSEN/FullyQualifiedGlobalStructuralElement.php
+++ b/src/Phan/Language/FQSEN/FullyQualifiedGlobalStructuralElement.php
@@ -91,14 +91,14 @@ abstract class FullyQualifiedGlobalStructuralElement extends AbstractFQSEN
         // name to the namespace.
         $name_parts = \explode('\\', $name);
         $name = \array_pop($name_parts);
-        $namespace = \implode('\\', \array_merge([$namespace], $name_parts));
+        foreach ($name_parts as $part) {
+            $namespace .= '\\' . $part;
+        }
         $namespace = self::cleanNamespace($namespace);
 
         // use the canonicalName for $name instead of strtolower - Some subclasses(constants) are case sensitive.
-        $key = implode('|', [
-            static::class,
-            static::toString(\strtolower($namespace), static::canonicalLookupKey($name), $alternate_id)
-        ]);
+        $key = static::class . '|' .
+            static::toString(\strtolower($namespace), static::canonicalLookupKey($name), $alternate_id);
 
         $fqsen = self::memoizeStatic($key, function () use ($namespace, $name, $alternate_id) {
             return new static(
@@ -126,16 +126,16 @@ abstract class FullyQualifiedGlobalStructuralElement extends AbstractFQSEN
         return self::memoizeStatic($key, function () use ($fully_qualified_string) {
 
             // Split off the alternate_id
-            $parts = explode(',', $fully_qualified_string);
+            $parts = \explode(',', $fully_qualified_string);
             $fqsen_string = $parts[0];
             $alternate_id = (int)($parts[1] ?? 0);
 
-            $parts = explode('\\', $fqsen_string);
-            $name = array_pop($parts);
+            $parts = \explode('\\', $fqsen_string);
+            $name = \array_pop($parts);
 
             \assert(!empty($name), "The name cannot be empty");
 
-            $namespace = '\\' . implode('\\', array_filter($parts));
+            $namespace = '\\' . \implode('\\', \array_filter($parts));
 
             \assert(!empty($namespace), "The namespace cannot be empty");
 
@@ -175,13 +175,13 @@ abstract class FullyQualifiedGlobalStructuralElement extends AbstractFQSEN
         }
 
         // Split off the alternate ID
-        $parts = explode(',', $fqsen_string);
+        $parts = \explode(',', $fqsen_string);
         $fqsen_string = $parts[0];
         $alternate_id = (int)($parts[1] ?? 0);
 
-        $parts = explode('\\', $fqsen_string);
+        $parts = \explode('\\', $fqsen_string);
         // Split the parts into the namespace(0 or more components) and the last name.
-        $name = array_pop($parts);
+        $name = \array_pop($parts);
 
         \assert(!empty($name), "The name cannot be empty");
 
@@ -193,7 +193,7 @@ abstract class FullyQualifiedGlobalStructuralElement extends AbstractFQSEN
             );
         }
 
-        $namespace = implode('\\', array_filter($parts));
+        $namespace = \implode('\\', \array_filter($parts));
 
         // n.b.: Functions must override this method because
         //       they don't prefix the namespace for naked


### PR DESCRIPTION
`$x .= $str` is efficient and doesn't require creating a temporary
array.
PHP can efficiently append if there aren't any other references to that string