### PR TITLE
WIP[BROKEN] warn about invalid callables in internal functions

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,12 @@ Phan NEWS
 ?? ??? 2019, Phan 1.2.5 (dev)
 -----------------------
 
+New features(Analysis):
++ Be more consistent warning about invalid callables passed to internal functions such as `register_shutdown_function` (#2046)
+
+Plugins:
++ Add `HandleLazyLoadInternalFunctionCapability` so that plugins can modify Phan's information about internal global functions when those functions are loaded after analysis starts.
+
 18 Feb 2019, Phan 1.2.4
 -----------------------
 

--- a/src/Phan/CodeBase.php
+++ b/src/Phan/CodeBase.php
@@ -30,6 +30,7 @@ use Phan\Language\NamespaceMapEntry;
 use Phan\Language\UnionType;
 use Phan\Library\Map;
 use Phan\Library\Set;
+use Phan\Plugin\ConfigPluginSet;
 use ReflectionClass;
 
 use function count;
@@ -1427,6 +1428,7 @@ class CodeBase
                     $function->setRealParameterList(Parameter::listFromReflectionParameterList($reflection_function->getParameters()));
                 }
                 $this->addFunction($function);
+                $this->updatePluginsOnLazyLoadInternalFunction($function);
             }
 
             return true;
@@ -1437,11 +1439,17 @@ class CodeBase
                 new \ReflectionFunction($name)
             ) as $function) {
                 $this->addFunction($function);
+                $this->updatePluginsOnLazyLoadInternalFunction($function);
             }
 
             return true;
         }
         return false;
+    }
+
+    private function updatePluginsOnLazyLoadInternalFunction(Func $function)
+    {
+        ConfigPluginSet::instance()->handleLazyLoadInternalFunction($this, $function);
     }
 
     /**

--- a/src/Phan/Language/Element/FunctionInterface.php
+++ b/src/Phan/Language/Element/FunctionInterface.php
@@ -340,10 +340,17 @@ interface FunctionInterface extends AddressableElementInterface
     public function analyzeFunctionCall(CodeBase $code_base, Context $context, array $args);
 
     /**
-     * If callers need to invoke multiple closures, they should pass in a closure to invoke multiple closures.
+     * Make additional analysis logic of this function/method use $closure
+     * If callers need to invoke multiple closures, they should pass in a closure to invoke multiple closures or use addFunctionCallAnalyzer.
      * @return void
      */
     public function setFunctionCallAnalyzer(\Closure $closure);
+
+    /**
+     * If callers need to invoke multiple closures, they should pass in a closure to invoke multiple closures.
+     * @return void
+     */
+    public function addFunctionCallAnalyzer(\Closure $closure);
 
     /**
      * Initialize the inner scope of this method with variables created from the parameters.

--- a/src/Phan/Language/Element/FunctionTrait.php
+++ b/src/Phan/Language/Element/FunctionTrait.php
@@ -1022,11 +1022,24 @@ trait FunctionTrait
 
     /**
      * Make additional analysis logic of this function/method use $closure
-     * If callers need to invoke multiple closures, they should pass in a closure to invoke multiple closures.
+     * If callers need to invoke multiple closures, they should pass in a closure to invoke multiple closures or use addFunctionCallAnalyzer.
      * @return void
      */
     public function setFunctionCallAnalyzer(Closure $closure)
     {
+        $this->function_call_analyzer_callback = $closure;
+    }
+
+    /**
+     * Make additional analysis logic of this function/method use $closure in addition to any other closures.
+     * @return void
+     */
+    public function addFunctionCallAnalyzer(Closure $closure)
+    {
+        $old_closure = $this->function_call_analyzer_callback;
+        if ($old_closure) {
+            $closure = ConfigPluginSet::mergeAnalyzeFunctionCallClosures($old_closure, $closure);
+        }
         $this->function_call_analyzer_callback = $closure;
     }
 

--- a/src/Phan/Language/Type/FunctionLikeDeclarationType.php
+++ b/src/Phan/Language/Type/FunctionLikeDeclarationType.php
@@ -627,6 +627,11 @@ abstract class FunctionLikeDeclarationType extends Type implements FunctionInter
         throw new \AssertionError('unexpected call to ' . __METHOD__);
     }
 
+    public function addFunctionCallAnalyzer(Closure $analyzer)
+    {
+        throw new \AssertionError('unexpected call to ' . __METHOD__);
+    }
+
     public function setDependentReturnTypeClosure(Closure $analyzer)
     {
         throw new \AssertionError('unexpected call to ' . __METHOD__);

--- a/src/Phan/PluginV2/HandleLazyLoadInternalFunctionCapability.php
+++ b/src/Phan/PluginV2/HandleLazyLoadInternalFunctionCapability.php
@@ -1,0 +1,29 @@
+<?php declare(strict_types=1);
+
+namespace Phan\PluginV2;
+
+use Phan\CodeBase;
+use Phan\Language\Element\Func;
+
+/**
+ * HandleLazyLoadInternalFunctionCapability is used when you want to modify some subset of global functions used in the program,
+ * when some global functions (such as register_shutdown_function) won't be loaded until the analysis phase.
+ */
+interface HandleLazyLoadInternalFunctionCapability
+{
+    /**
+     * This method is called after Phan lazily loads a global internal function.
+     *
+     * @param CodeBase $code_base
+     * The code base in which the function exists
+     *
+     * @param Func $function
+     * The function that was just now added to $code_base
+     *
+     * @return void
+     */
+    public function handleLazyLoadInternalFunction(
+        CodeBase $code_base,
+        Func $function
+    );
+}

--- a/tests/Phan/CLITest.php
+++ b/tests/Phan/CLITest.php
@@ -77,10 +77,10 @@ final class CLITest extends BaseTest
      */
     public function testSetsConfigOptions(array $expected_changed_options, array $opts, array $extra = [])
     {
-        $opts = $opts + ['project-root-directory' => dirname(__DIR__) . '/misc/config/'];
-        $expected_changed_options = $expected_changed_options + ['directory_list' => ['src']];
+        $opts += ['project-root-directory' => dirname(__DIR__) . '/misc/config/'];
+        $expected_changed_options += ['directory_list' => ['src']];
         if (!extension_loaded('pcntl')) {
-            $expected_changed_options = $expected_changed_options + ['language_server_use_pcntl_fallback' => true];
+            $expected_changed_options += ['language_server_use_pcntl_fallback' => true];
         }
         $cli = CLI::fromRawValues($opts, []);
         $changed = [];

--- a/tests/plugin_test/expected/093_multiple_format_strings.php.expected
+++ b/tests/plugin_test/expected/093_multiple_format_strings.php.expected
@@ -1,0 +1,1 @@
+src/093_multiple_format_strings.php:11 PhanTypeMismatchArgument Argument 1 (x) is 'xa'|'xb' but \expect_ab() takes 'ax'|'bx' defined at src/093_multiple_format_strings.php:6

--- a/tests/plugin_test/expected/094_shutdown_function.php.expected
+++ b/tests/plugin_test/expected/094_shutdown_function.php.expected
@@ -1,0 +1,2 @@
+src/094_shutdown_function.php:3 PhanUndeclaredFunctionInCallable Call to undeclared function notafunction in callable
+src/094_shutdown_function.php:4 PhanUndeclaredClassInCallable Reference to undeclared class \MissingClass in callable \MissingClass::notafunction

--- a/tests/plugin_test/src/093_multiple_format_strings.php
+++ b/tests/plugin_test/src/093_multiple_format_strings.php
@@ -1,0 +1,11 @@
+<?php
+
+/**
+ * @param 'ax'|'bx' $x
+ */
+function expect_ab($x) {
+    var_export($x);
+}
+
+expect_ab(sprintf(rand(0, 2) ? 'a%s' : 'b%s', 'x'));
+expect_ab(sprintf(rand(0, 2) ? '%sa' : '%sb', 'x'));

--- a/tests/plugin_test/src/094_shutdown_function.php
+++ b/tests/plugin_test/src/094_shutdown_function.php
@@ -1,0 +1,4 @@
+<?php
+
+register_shutdown_function('notafunction');  // Fails to emit PhanUndeclaredFunctionInCallable
+register_shutdown_function(['MissingClass', 'notafunction']);  // Fails to emit PhanUndeclaredFunctionInCallable or anything else


### PR DESCRIPTION
Phan fails to warn about invalid callables passed
to functions such as register_shutdown_function

For #2046

TODO: Finish implementing this